### PR TITLE
Update Ubuntu and Kong versions

### DIFF
--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -28,7 +28,7 @@ sudo chmod 755 /usr/local/bin/deck
 echo "Installing Kong"
 EE_LICENSE=$(aws_get_parameter ee/license)
 EE_CREDS=$(aws_get_parameter ee/bintray-auth)
-if [ "$EE_LICENSE" != "placeholder" ]; then
+if [ "$EE_LICENSE" != "" ] && [ "$EE_LICENSE" != "placeholder" ]; then
     curl -sL https://kong.bintray.com/kong-enterprise-edition-deb/dists/${EE_PKG} \
         -u $EE_CREDS \
         -o ${EE_PKG} 

--- a/variables.tf
+++ b/variables.tf
@@ -168,12 +168,7 @@ variable "ec2_ami" {
   type        = map(string)
 
   default = {
-    us-east-1    = "ami-097f2dec72be3d174"
-    us-east-2    = "ami-0ba142a7063a73767"
-    us-west-1    = "ami-07b69f5dcdbb4abaf"
-    us-west-2    = "ami-028b81a9f357b2b96"
-    eu-central-1 = "ami-0cbcfdbe2416ea8df"
-    eu-west-1    = "ami-0eb00845cbc30b475"
+    us-east-1    = "ami-05c457ee3f21d75f8"
   }
 }
 
@@ -239,14 +234,14 @@ variable "ee_pkg" {
   description = "Filename of the Enterprise Edition package"
   type        = string
 
-  default = "kong-enterprise-edition-1.3.0.1.bionic.all.deb "
+  default = "kong-enterprise-edition2.1.1.focal.all.deb "
 }
 
 variable "ce_pkg" {
   description = "Filename of the Community Edition package"
   type        = string
 
-  default = "kong-1.5.0.bionic.amd64.deb"
+  default = "kong-2.1.1.focal.amd64.deb"
 }
 
 # Load Balancer settings
@@ -514,7 +509,7 @@ variable "deck_version" {
   description = "Version of decK to install"
   type        = string
 
-  default = "1.0.0"
+  default = "1.2.1"
 }
 
 variable "db_final_snapshot_identifier" {


### PR DESCRIPTION
1. Ubuntu 18.10 Cosmic reached end of life on July 19, 2019. Updates with Ubuntu 20.04 Focal.
2. Updated Kong to 2.1.1
3. Updated deck version to 1.2.1
4. Fix EE license check to ignore include empty (returned in case of insufficient permissions)