### PR TITLE
FAI-1267 - extend kong's nginx access log with perf info

### DIFF
--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -172,6 +172,14 @@ events {
 }
 
 http {
+    # extend default "combined" format by adding perf timing. Also - trying to get request IDs from headers, e.g., x-vercel-id
+    # see https://docs.nginx.com/nginx/admin-guide/monitoring/logging/ for config parameters
+    log_format combined_with_perf_data '$remote_addr - $remote_user [$time_local] '
+                                       '"$request" $status $body_bytes_sent '
+                                       '"$http_referer" "$http_user_agent"'
+                                       'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"'
+                                       'vercelId="http_x_vercel_id"';
+    access_log    /dev/stdout combined_with_perf_data;
     include nginx-kong.conf;
 }
 EOF

--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -176,9 +176,8 @@ http {
     # see https://docs.nginx.com/nginx/admin-guide/monitoring/logging/ for config parameters
     log_format combined_with_perf_data '$remote_addr - $remote_user [$time_local] '
                                        '"$request" $status $body_bytes_sent '
-                                       '"$http_referer" "$http_user_agent"'
-                                       'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"'
-                                       'vercelId="http_x_vercel_id"';
+                                       '"$http_referer" "$http_user_agent" '
+                                       'rt="$request_time" uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
     access_log    /dev/stdout combined_with_perf_data;
     include nginx-kong.conf;
 }


### PR DESCRIPTION
## Description

Extending access log format of kong's nginx.conf with perf info. 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues



## Migration notes

> Describe migration notes if any

## Extra info

See also https://github.com/faros-ai/metabase/pull/34
