### PR TITLE
FAI-1227 - Store LB access logs in s3

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/aws" {
   version = "3.73.0"
   hashes = [
+    "h1:4RDhEdSMfp46w3nhMg5ILI2uD9mui6JBYMCZU8Sb76I=",
     "h1:ntQzWbRPf6wPXY/EqKN0AwTRYquGV5ey+tMey5/i8SM=",
     "zh:04a2203758c8992ef4b70d5a0163294063fd3ddd9570db1101150717c274e7d9",
     "zh:2f9f1b02a7f8a5aa01fbef5d155125658b62f60ec35bcae64f4314ef4a920922",

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ No requirements.
 | aws\_private\_subnet\_ids | Private subnet Ids | `list(string)` | n/a | yes |
 | aws\_public\_subnet\_ids | Private subnet Ids | `list(string)` | n/a | yes |
 | environment | Resource environment tag (i.e. dev, stage, prod) | `string` | n/a | yes |
+| lb\_logging\_bucket | The s3 bucket which LB access logs should be stored to | `string` | n/a | yes |
 | ssl\_cert\_admin\_domain | SSL certificate domain name for the Kong Admin API HTTPS listener | `string` | n/a | yes |
 | ssl\_cert\_external\_arn | SSL certificate ARN for the external Kong Proxy HTTPS listener | `string` | n/a | yes |
 | ssl\_cert\_internal\_arn | SSL certificate ARN for the internal Kong Proxy HTTPS listener | `string` | n/a | yes |
@@ -119,6 +120,7 @@ No requirements.
 | enable\_internal\_lb | Boolean to enable/create the internal load balancer for the forward proxy | `string` | `true` | no |
 | enable\_redis | Boolean to enable redis AWS resource | `string` | `false` | no |
 | external\_cidr\_blocks | External ingress access to Kong Proxy via the load balancer | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| external\_lb\_logging\_prefix | s3 prefix for the external LB access logs | `string` | `"kong-external-lb"` | no |
 | health\_check\_healthy\_threshold | Number of consecutives checks before a unhealthy target is considered healthy | `string` | `5` | no |
 | health\_check\_interval | Seconds between health checks | `string` | `5` | no |
 | health\_check\_matcher | HTTP Code(s) that result in a successful response from a target (comma delimited) | `string` | `200` | no |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ No requirements.
 | aws\_private\_subnet\_ids | Private subnet Ids | `list(string)` | n/a | yes |
 | aws\_public\_subnet\_ids | Private subnet Ids | `list(string)` | n/a | yes |
 | environment | Resource environment tag (i.e. dev, stage, prod) | `string` | n/a | yes |
+| external\_lb\_logging\_prefix | s3 prefix for the external LB access logs | `string` | n/a | yes |
 | lb\_logging\_bucket | The s3 bucket which LB access logs should be stored to | `string` | n/a | yes |
 | ssl\_cert\_admin\_domain | SSL certificate domain name for the Kong Admin API HTTPS listener | `string` | n/a | yes |
 | ssl\_cert\_external\_arn | SSL certificate ARN for the external Kong Proxy HTTPS listener | `string` | n/a | yes |
@@ -120,7 +121,6 @@ No requirements.
 | enable\_internal\_lb | Boolean to enable/create the internal load balancer for the forward proxy | `string` | `true` | no |
 | enable\_redis | Boolean to enable redis AWS resource | `string` | `false` | no |
 | external\_cidr\_blocks | External ingress access to Kong Proxy via the load balancer | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| external\_lb\_logging\_prefix | s3 prefix for the external LB access logs | `string` | `"kong-external-lb"` | no |
 | health\_check\_healthy\_threshold | Number of consecutives checks before a unhealthy target is considered healthy | `string` | `5` | no |
 | health\_check\_interval | Seconds between health checks | `string` | `5` | no |
 | health\_check\_matcher | HTTP Code(s) that result in a successful response from a target (comma delimited) | `string` | `200` | no |

--- a/lb.tf
+++ b/lb.tf
@@ -53,11 +53,11 @@ resource "aws_lb" "external" {
     delete = var.lb_deletion_timeout
   }
   dynamic "access_logs" {
-    for_each = toset(length(var.lb_logging_bucket) > 0 ? [lb_logging_bucket] : [])
+    for_each = toset(length(var.lb_logging_bucket) > 0 ? [var.lb_logging_bucket] : [])
     content {
-      bucket = access_logs.value
-      prefix = length(var.external_lb_logging_prefix) > 0 ? var.external_lb_logging_prefix : format("%s-%s-external", var.service, var.environment)
-      enabled = length(var.lb_logging_bucket) > 0
+      bucket  = access_logs.value
+      prefix  = length(var.external_lb_logging_prefix) > 0 ? var.external_lb_logging_prefix : format("%s-%s-external", var.service, var.environment)
+      enabled = true
     }
   }
 }

--- a/lb.tf
+++ b/lb.tf
@@ -52,10 +52,13 @@ resource "aws_lb" "external" {
     create = var.lb_creation_timeout
     delete = var.lb_deletion_timeout
   }
-  access_logs {
-    bucket  = var.lb_logging_bucket
-    prefix  = var.external_lb_logging_prefix
-    enabled = true
+  dynamic "access_logs" {
+    for_each = toset(length(var.lb_logging_bucket) > 0 ? [lb_logging_bucket] : [])
+    content {
+      bucket = access_logs.value
+      prefix = length(var.external_lb_logging_prefix) > 0 ? var.external_lb_logging_prefix : format("%s-%s-external", var.service, var.environment)
+      enabled = length(var.lb_logging_bucket) > 0
+    }
   }
 }
 

--- a/lb.tf
+++ b/lb.tf
@@ -52,6 +52,11 @@ resource "aws_lb" "external" {
     create = var.lb_creation_timeout
     delete = var.lb_deletion_timeout
   }
+  access_logs {
+    bucket  = var.lb_logging_bucket
+    prefix  = var.external_lb_logging_prefix
+    enabled = true
+  }
 }
 
 resource "aws_lb_listener" "external-https" {

--- a/variables.tf
+++ b/variables.tf
@@ -604,5 +604,4 @@ variable "lb_logging_bucket" {
 variable "external_lb_logging_prefix" {
   description = "s3 prefix for the external LB access logs"
   type        = string
-  default     = "kong-external-lb"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -595,3 +595,14 @@ variable "admin_user" {
   type        = string
   default     = "kong-admin"
 }
+
+variable "lb_logging_bucket" {
+  description = "The s3 bucket which LB access logs should be stored to"
+  type        = string
+}
+
+variable "external_lb_logging_prefix" {
+  description = "s3 prefix for the external LB access logs"
+  type        = string
+  default     = "kong-external-lb"
+}


### PR DESCRIPTION
## Description

Stores LB access logs in S3

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

https://faros-ai.atlassian.net/browse/FAI-1227