### PR TITLE
FAI-1267 - access logs to file, not stdout

### DIFF
--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -172,14 +172,15 @@ events {
 }
 
 http {
+    include nginx-kong.conf;
     # extend default "combined" format by adding perf timing. Also - trying to get request IDs from headers, e.g., x-vercel-id
     # see https://docs.nginx.com/nginx/admin-guide/monitoring/logging/ for config parameters
     log_format combined_with_perf_data '$remote_addr - $remote_user [$time_local] '
                                        '"$request" $status $body_bytes_sent '
                                        '"$http_referer" "$http_user_agent" '
                                        'rt="$request_time" uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
-    access_log    /dev/stdout combined_with_perf_data;
-    include nginx-kong.conf;
+    access_log logs/access.log combined_with_perf_data;
+
 }
 EOF
 chown root:kong /usr/local/kong/nginx.conf


### PR DESCRIPTION
## Description

access logs should go to access.log, not stdout

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

> Fix [#1]() 

## Migration notes

> Describe migration notes if any

## Extra info

> Add any additional information
