### PR TITLE
Drop invalid headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ No requirements.
 | default\_security\_group\_name | Name of the default VPC security group for EC2 access | `string` | `"default"` | no |
 | deregistration\_delay | Seconds to wait before changing the state of a deregistering target from draining to unused | `string` | `300` | no |
 | description | Resource description tag | `string` | `"Kong API Gateway"` | no |
+| drop\_invalid\_header\_fields | Drop invalid headers in LB | `bool` | `false` | no |
 | ec2\_ami | Map of Ubuntu Minimal AMIs by region | `map(string)` | <pre>{<br>  "us-east-1": "ami-04cc2b0ad9e30a9c8"<br>}</pre> | no |
 | ec2\_instance\_type | EC2 instance type | `string` | `"t2.micro"` | no |
 | ec2\_key\_name | AWS SSH Key | `string` | `""` | no |

--- a/lb.tf
+++ b/lb.tf
@@ -38,6 +38,7 @@ resource "aws_lb" "external" {
 
   enable_deletion_protection = var.enable_deletion_protection
   idle_timeout               = var.idle_timeout
+  drop_invalid_header_fields = true
 
   tags = merge(
     {
@@ -272,6 +273,7 @@ resource "aws_lb" "internal" {
 
   enable_deletion_protection = var.enable_deletion_protection
   idle_timeout               = var.idle_timeout
+  drop_invalid_header_fields = true
 
   tags = merge(
     {

--- a/lb.tf
+++ b/lb.tf
@@ -38,7 +38,7 @@ resource "aws_lb" "external" {
 
   enable_deletion_protection = var.enable_deletion_protection
   idle_timeout               = var.idle_timeout
-  drop_invalid_header_fields = true
+  drop_invalid_header_fields = var.drop_invalid_header_fields
 
   tags = merge(
     {
@@ -273,7 +273,7 @@ resource "aws_lb" "internal" {
 
   enable_deletion_protection = var.enable_deletion_protection
   idle_timeout               = var.idle_timeout
-  drop_invalid_header_fields = true
+  drop_invalid_header_fields = var.drop_invalid_header_fields
 
   tags = merge(
     {

--- a/variables.tf
+++ b/variables.tf
@@ -609,3 +609,10 @@ variable "external_lb_logging_prefix" {
 
   default = ""
 }
+
+variable "drop_invalid_header_fields" {
+  description = "Drop invalid headers in LB"
+  type        = bool
+
+  default = false
+}


### PR DESCRIPTION
## Description

Drop invalid headers. This comes from the TFSEC recommendation: https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/elb/drop-invalid-headers/

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

https://faros-ai.atlassian.net/browse/FAI-2017
