### PR TITLE
FAI-2169 - Export RDS ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ No requirements.
 | lb\_endpoint\_external | The external load balancer endpoint |
 | lb\_endpoint\_internal | The internal load balancer endpoint |
 | master\_password | The master password for Kong |
+| rds\_arn | ARN of the Kong database |
 | rds\_endpoint | The endpoint for the Kong database |
 | rds\_id | ID of the Kong database |
 | rds\_password | The database password for Kong |

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "rds_id" {
   description = "ID of the Kong database"
 }
 
+output "rds_arn" {
+  value       = coalesce(aws_db_instance.kong.*.arn)
+  description = "ARN of the Kong database"
+}
+
 output "rds_endpoint" {
   value       = coalesce(aws_rds_cluster.kong.*.endpoint)
   description = "The endpoint for the Kong database"


### PR DESCRIPTION
## Description

Export RDS ARN. The ARN is required to setup automated cross-region database backups.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Related issues

https://faros-ai.awsapps.com/start#/