### PR TITLE
Allow logrotate write access to kong log dir

### DIFF
--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -206,6 +206,11 @@ cat <<'EOF' > /etc/logrotate.d/kong
 }
 EOF
 
+# Allow write access for logrotate
+cat <<'EOF' > /etc/logrotate.d/kong
+ReadWritePaths=/usr/local/kong/logs
+EOF
+
 # Start Kong under supervision
 echo "Starting Kong under supervision"
 mkdir -p /etc/sv/kong /etc/sv/kong/log


### PR DESCRIPTION
## Description

Allows `logrotate` access to rotate Kong logs so we don't fill up the disks.  Fix from: https://askubuntu.com/questions/1275668/logrotate-succeeds-when-manually-run-as-root-but-fails-with-read-only-file-sys

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related issues

June 7th outage: https://status.faros.ai/incidents/bztgcxytfjxr