### PR TITLE
Add Cloudwatch Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ No requirements.
 | bastion\_cidr\_blocks | Bastion hosts allowed access to PostgreSQL and Kong Admin | `list(string)` | <pre>[<br>  "127.0.0.1/32"<br>]</pre> | no |
 | ce\_pkg | Url for Community Edition package matching the OS distro | `string` | `"https://download.konghq.com/gateway-2.x-ubuntu-focal/pool/all/k/kong/kong_2.3.3_amd64.deb"` | no |
 | cloudwatch\_actions | List of cloudwatch actions for Alert/Ok | `list(string)` | `[]` | no |
+| cloudwatch\_agent\_kong\_config | Cloudwatch Agent Kong Config | `string` | `""` | no |
+| cloudwatch\_agent\_system\_config | Cloudwatch Agent System Config | `string` | `""` | no |
 | db\_backup\_retention\_period | The number of days to retain backups | `string` | `7` | no |
 | db\_engine\_mode | Engine mode for Aurora | `string` | `"provisioned"` | no |
 | db\_engine\_version | Database engine version | `string` | `"11.4"` | no |

--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -9,6 +9,15 @@ aws_get_parameter() {
         --query Parameter.Value 2>/dev/null
 }
 
+# Install Cloudwatch Agent
+curl -sL https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb \
+  -o amazon-cloudwatch-agent.deb
+dpkg -i amazon-cloudwatch-agent.deb
+
+# Pull config and start Cloudwatch Agent
+amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${CLOUDWATCH_SYSTEM_CONFIG} -s
+amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c ssm:${CLOUDWATCH_KONG_CONFIG} -s
+
 # Enable auto updates
 echo "Enabling auto updates"
 echo unattended-upgrades unattended-upgrades/enable_auto_updates boolean true \

--- a/cloud-init.tf
+++ b/cloud-init.tf
@@ -14,8 +14,8 @@ locals {
     SESSION_SECRET           = random_string.session_secret.result
     ADMIN_CERT_DOMAIN        = var.ssl_cert_admin_domain
     ADMIN_USER               = var.admin_user
-    CLOUDWATCH_SYSTEM_CONFIG = var.cloudwatch_agent_system_config
-    CLOUDWATCH_KONG_CONFIG   = var.cloudwatch_agent_kong_config
+    CLOUDWATCH_SYSTEM_CONFIG = var.cloudwatch_agent_system_config.name
+    CLOUDWATCH_KONG_CONFIG   = var.cloudwatch_agent_kong_config.name
   })
 
 }

--- a/cloud-init.tf
+++ b/cloud-init.tf
@@ -2,18 +2,20 @@ locals {
   cloud_init = templatefile("${path.module}/cloud-init.cfg", {})
 
   shell_script = templatefile("${path.module}/cloud-init.sh", {
-    DB_USER           = replace(format("%s_%s", var.service, var.environment), "-", "_")
-    CE_PKG            = var.ce_pkg
-    EE_PKG            = var.ee_pkg
-    PARAMETER_PATH    = format("/%s/%s", var.service, var.environment)
-    REGION            = data.aws_region.current.name
-    VPC_CIDR_BLOCK    = var.vpc_cidr_block
-    DECK_VERSION      = var.deck_version
-    MANAGER_HOST      = local.manager_host
-    PORTAL_HOST       = local.portal_host
-    SESSION_SECRET    = random_string.session_secret.result
-    ADMIN_CERT_DOMAIN = var.ssl_cert_admin_domain
-    ADMIN_USER        = var.admin_user
+    DB_USER                  = replace(format("%s_%s", var.service, var.environment), "-", "_")
+    CE_PKG                   = var.ce_pkg
+    EE_PKG                   = var.ee_pkg
+    PARAMETER_PATH           = format("/%s/%s", var.service, var.environment)
+    REGION                   = data.aws_region.current.name
+    VPC_CIDR_BLOCK           = var.vpc_cidr_block
+    DECK_VERSION             = var.deck_version
+    MANAGER_HOST             = local.manager_host
+    PORTAL_HOST              = local.portal_host
+    SESSION_SECRET           = random_string.session_secret.result
+    ADMIN_CERT_DOMAIN        = var.ssl_cert_admin_domain
+    ADMIN_USER               = var.admin_user
+    CLOUDWATCH_SYSTEM_CONFIG = var.cloudwatch_agent_system_config
+    CLOUDWATCH_KONG_CONFIG   = var.cloudwatch_agent_kong_config
   })
 
 }

--- a/iam.tf
+++ b/iam.tf
@@ -10,6 +10,16 @@ data "aws_iam_policy_document" "kong-ssm" {
   }
 
   statement {
+    actions   = ["ssm:GetParameter"]
+    resources = ["arn:aws:ssm:*:*:parameter/${var.cloudwatch_agent_system_config}"]
+  }
+
+  statement {
+    actions   = ["ssm:GetParameter"]
+    resources = ["arn:aws:ssm:*:*:parameter/${var.cloudwatch_agent_kong_config}"]
+  }
+
+  statement {
     actions   = ["kms:Decrypt"]
     resources = [aws_kms_key.kong.arn]
   }
@@ -41,6 +51,11 @@ resource "aws_iam_role" "kong" {
 resource "aws_iam_role_policy_attachment" "kong_ssm_managed_instance_policy_attach" {
   role       = aws_iam_role.kong.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "kong_cloudwatch_agent_server_policy_attach" {
+  role       = aws_iam_role.kong.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
 resource "aws_iam_instance_profile" "kong" {

--- a/variables.tf
+++ b/variables.tf
@@ -630,3 +630,17 @@ variable "drop_invalid_header_fields" {
 
   default = false
 }
+
+variable "cloudwatch_agent_system_config" {
+  description = "Cloudwatch Agent System Config"
+  type        = string
+
+  default = ""
+}
+
+variable "cloudwatch_agent_kong_config" {
+  description = "Cloudwatch Agent Kong Config"
+  type        = string
+
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -635,12 +635,14 @@ variable "cloudwatch_agent_system_config" {
   description = "Cloudwatch Agent Config for system metrics"
   type        = string
 
-  default = ""
+  # set non-existent parameter name to avoid granting broad permissions
+  default = "non-existent-parameter"
 }
 
 variable "cloudwatch_agent_kong_config" {
   description = "Cloudwatch Agent Config for Kong"
   type        = string
 
-  default = ""
+  # set non-existent parameter name to avoid granting broad permissions
+  default = "non-existent-parameter"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -632,14 +632,14 @@ variable "drop_invalid_header_fields" {
 }
 
 variable "cloudwatch_agent_system_config" {
-  description = "Cloudwatch Agent System Config"
+  description = "Cloudwatch Agent Config for system metrics"
   type        = string
 
   default = ""
 }
 
 variable "cloudwatch_agent_kong_config" {
-  description = "Cloudwatch Agent Kong Config"
+  description = "Cloudwatch Agent Config for Kong"
   type        = string
 
   default = ""


### PR DESCRIPTION
## Description

Add Cloudwatch Agent. 

This PR should be merged deployed at the same time as the `hephaestus` PR so that the necessary Cloudwatch Agent configuration is stored in the SSM parameter.


## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
