### PR TITLE
Do not run logrotate during init

### DIFF
--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -219,7 +219,6 @@ EOF
 cat <<'EOF' >> /lib/systemd/system/logrotate.service
 ReadWritePaths=/usr/local/kong/logs
 EOF
-systemctl daemon-reload && systemctl start logrotate
 
 # Start Kong under supervision
 echo "Starting Kong under supervision"


### PR DESCRIPTION
## Description

`logrotate` runs as a `systemctl` timer on Ubuntu and not as a `systemctl` service. Therefore there is no need reload `systemctl` configs and run `logrotate` during the init script. `logrotate` will run properly on the next timer run after startup.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change